### PR TITLE
fix(cli): separate cache keys per arch

### DIFF
--- a/cli/action.yml
+++ b/cli/action.yml
@@ -31,7 +31,7 @@ runs:
       id: cache-cli
       with:
         path: ${{runner.tool_cache}}/tree-sitter/cli
-        key: tree-sitter-cli-${{runner.os}}-${{env.TREE_SITTER_REF}}
+        key: tree-sitter-cli-${{runner.os}}-${{runner.arch}}-${{env.TREE_SITTER_REF}}
     - name: Set up Rust
       uses: actions-rust-lang/setup-rust-toolchain@v1
       if: >-
@@ -74,4 +74,4 @@ runs:
         steps.cache-cli.outputs.cache-hit != 'true'
       with:
         path: ${{runner.tool_cache}}/tree-sitter/cli
-        key: tree-sitter-cli-${{runner.os}}-${{env.TREE_SITTER_REF}}
+        key: tree-sitter-cli-${{runner.os}}-${{runner.arch}}-${{env.TREE_SITTER_REF}}


### PR DESCRIPTION
Add `${{runner.arch}}` to cache key to prevent architecture mismatch between macOS-13 (x86_64) and macOS-15 (ARM64) runners.

Fixes #2