### PR TITLE
fix: redirect stderr of `tree-sitter init-config`.

### DIFF
--- a/cli/action.yml
+++ b/cli/action.yml
@@ -65,7 +65,7 @@ runs:
       working-directory: ${{runner.temp}}
       shell: bash
       run: |-
-        config="$(tree-sitter init-config | cut -c32- | tr '\\' '/')"
+        config="$(tree-sitter init-config 2>&1 | cut -c32- | tr '\\' '/')"
         printf '{"parser-directories":["%q"]}' "${GITHUB_WORKSPACE%/*}" > "$config"
     - name: Save tree-sitter CLI to cache
       uses: actions/cache/save@v4


### PR DESCRIPTION
Starting with tree-sitter 0.26.2, the output of this command is logged to stderr rather than stdout.

Originally saw this issue here: https://github.com/ribru17/ts_query_ls/actions/runs/20084727359/job/57619573862?pr=257